### PR TITLE
Updated Gurobi to v9.1.2 to avoid expiring license on WSL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,21 +133,21 @@ cd ..
 
 Install Gurobi:
 ```
-wget https://packages.gurobi.com/9.0/gurobi9.0.0_linux64.tar.gz
-tar -xvf gurobi9.0.0_linux64.tar.gz
-cd gurobi900/linux64/src/build
+wget https://packages.gurobi.com/9.1/gurobi9.1.2_linux64.tar.gz
+tar -xvf gurobi9.1.2_linux64.tar.gz
+cd gurobi912/linux64/src/build
 sed -ie 's/^C++FLAGS =.*$/& -fPIC/' Makefile
 make
 cp libgurobi_c++.a ../../lib/
 cd ../../
-cp lib/libgurobi90.so /usr/local/lib
+cp lib/libgurobi91.so /usr/local/lib
 python3 setup.py install
 cd ../../
 ```
 
 Update environment variables:
 ```
-export GUROBI_HOME="$PWD/gurobi900/linux64"
+export GUROBI_HOME="$PWD/gurobi912/linux64"
 export PATH="$PATH:${GUROBI_HOME}/bin"
 export CPATH="$CPATH:${GUROBI_HOME}/include"
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:${GUROBI_HOME}/lib
@@ -185,6 +185,7 @@ source gurobi_setup_path.sh
 
 
 Note that to run ERAN with Gurobi one needs to obtain an academic license for gurobi from https://user.gurobi.com/download/licenses/free-academic.
+If you plan on running ERAN on Windows WSL2, you might prefer requesting a cloud-based academic license at [https://license.gurobi.com](https://license.gurobi.com), in order to avoid [this issue](https://github.com/microsoft/WSL/issues/5352) with early-expiring licenses.
 
 To install the remaining python dependencies (numpy and tensorflow), type:
 

--- a/install.sh
+++ b/install.sh
@@ -58,21 +58,21 @@ make
 make install
 cd ..
 
-wget https://packages.gurobi.com/9.0/gurobi9.0.0_linux64.tar.gz
-tar -xvf gurobi9.0.0_linux64.tar.gz
-cd gurobi900/linux64/src/build
+wget https://packages.gurobi.com/9.1/gurobi9.1.2_linux64.tar.gz
+tar -xvf gurobi9.1.2_linux64.tar.gz
+cd gurobi912/linux64/src/build
 sed -ie 's/^C++FLAGS =.*$/& -fPIC/' Makefile
 make
 cp libgurobi_c++.a ../../lib/
 cd ../../
-cp lib/libgurobi90.so /usr/local/lib
+cp lib/libgurobi91.so /usr/local/lib
 python3 setup.py install
 cd ../../
-rm gurobi9.0.0_linux64.tar.gz
+rm gurobi9.1.2_linux64.tar.gz
 
 
 
-export GUROBI_HOME="$(pwd)/gurobi900/linux64"
+export GUROBI_HOME="$(pwd)/gurobi912/linux64"
 export PATH="${PATH}:/usr/lib:${GUROBI_HOME}/bin"
 export CPATH="${CPATH}:${GUROBI_HOME}/include"
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib:/usr/local/lib:${GUROBI_HOME}/lib


### PR DESCRIPTION
Hi, I have updated all references to the Gurobi optimizer to use the newer version v9.1.2 rather than v9.0.0.

This is particularly useful to Windows users that run the ERAN analyzer on WSL2 (Windows Subsystem for Linux 2).
In fact, on WSL2, Gurobi licenses expire after every system reboot due to [this issue](https://github.com/microsoft/WSL/issues/5352).

I have tested ERAN with Gurobi v9.1.2 on my local machine, running Ubuntu 20.04 on WSL2.
![eth-eran](https://user-images.githubusercontent.com/12381818/124286275-0eac3c00-db4f-11eb-89bb-f5b4c1c511db.png)
